### PR TITLE
Use python 3.6 on bionic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ros_workspace)
 
 find_package(ament_cmake_core REQUIRED)
 
-set(PYTHON_INSTALL_DIR "lib/python3.5/site-packages")
+set(PYTHON_INSTALL_DIR "lib/python3.6/site-packages")
 set(ament_cmake_package_templates_ENVIRONMENT_HOOK_PYTHONPATH "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package/template/environment_hook/pythonpath.sh.in")
 ament_environment_hooks("${ament_cmake_package_templates_ENVIRONMENT_HOOK_PYTHONPATH}")
 


### PR DESCRIPTION
I'm not sure what the optimal way to get the desired python interpreter version here is.

For now let's continue to hard code it.