### PR TITLE
Collect python version to use in pythonpath hook.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ project(ros_workspace)
 
 find_package(ament_cmake_core REQUIRED)
 
-set(PYTHON_INSTALL_DIR "lib/python3.5/site-packages")
+# Collect current python 3 version
+execute_process(COMMAND python3 -c "from distutils import sysconfig; print(sysconfig.get_python_version())" OUTPUT_VARIABLE PYTHON_MAJOR_MINOR OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(PYTHON_INSTALL_DIR "lib/python${PYTHON_MAJOR_MINOR}/site-packages")
 set(ament_cmake_package_templates_ENVIRONMENT_HOOK_PYTHONPATH "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package/template/environment_hook/pythonpath.sh.in")
 ament_environment_hooks("${ament_cmake_package_templates_ENVIRONMENT_HOOK_PYTHONPATH}")
 


### PR DESCRIPTION
Initially this was hardcoded. Since the python minor version depends on the target platform this will fetch it from the available python3 binary.

Replaces #3 