### PR TITLE
Add direct build dependency on ament_package.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <build_depend>ament_cmake_core</build_depend>
+  <build_depend>ament_package</build_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
 


### PR DESCRIPTION
This dependency was previously implied by the dependency on ament_cmake_core. Since we directly use environment script templates from ament_package let's make that direct dependency explicit.