### PR TITLE
Revert "add COLCON_PREFIX_PATH env var"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,8 @@ set(BINARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/path.sh")
 set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.sh")
 set(PYTHONPATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/pythonpath.sh.in")
 
-set(COLCON_PREFIX_PATH_HOOK "env_hook/colcon_prefix_path.sh")
-
 # Set environment hooks for default environment.
-ament_environment_hooks(
-  "${BINARY_PATH_HOOK}"
-  "${COLCON_PREFIX_PATH_HOOK}"
-  "${LIBRARY_PATH_HOOK}"
-  "${PYTHONPATH_HOOK}")
+ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
 
 ament_package()
 ament_generate_environment()

--- a/env_hook/colcon_prefix_path.sh
+++ b/env_hook/colcon_prefix_path.sh
@@ -1,3 +1,0 @@
-# copied from ros_workspace/env_hook/colcon_prefix_path.sh
-
-ament_prepend_unique_value COLCON_PREFIX_PATH "$AMENT_CURRENT_PREFIX"


### PR DESCRIPTION
Reverts ros2/ros_workspace#11

This hook is obsolete with colcon/colcon-ros#56 and colcon/colcon-ros#60.