### PR TITLE
support ament_package being installed with develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,22 @@ execute_process(COMMAND python3 -c "from distutils import sysconfig; print(sysco
 
 # Locate ament_package template files.
 set(PYTHON_INSTALL_DIR "lib/python${PYTHON_MAJOR_MINOR}/site-packages")
-set(AMENT_PACKAGE_TEMPLATE_DIR "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package/template")
+set(AMENT_PACKAGE_DIR "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package")
+if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
+  # Check for an .egg-link file and use the listed directory if it exists
+  get_filename_component(AMENT_PACKAGE_EGG_LINK "${AMENT_PACKAGE_DIR}" DIRECTORY)
+  set(AMENT_PACKAGE_EGG_LINK "${AMENT_PACKAGE_EGG_LINK}/ament-package.egg-link")
+  if(NOT EXISTS "${AMENT_PACKAGE_EGG_LINK}")
+    message(FATAL_ERROR "Could neither find '${AMENT_PACKAGE_DIR}' nor '${AMENT_PACKAGE_EGG_LINK}'")
+  endif()
+  file(STRINGS "${AMENT_PACKAGE_EGG_LINK}" AMENT_PACKAGE_DIR)
+  list(GET AMENT_PACKAGE_DIR 0 AMENT_PACKAGE_DIR)
+  set(AMENT_PACKAGE_DIR "${AMENT_PACKAGE_DIR}/ament_package")
+  if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
+    message(FATAL_ERROR "Could not find '${AMENT_PACKAGE_DIR}' listed in '${AMENT_PACKAGE_EGG_LINK}'")
+  endif()
+endif()
+set(AMENT_PACKAGE_TEMPLATE_DIR "${AMENT_PACKAGE_DIR}/template")
 set(BINARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/path.sh")
 set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.sh")
 set(PYTHONPATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/pythonpath.sh.in")


### PR DESCRIPTION
This will allow to build this package when `ament_package` was installed using `--symlink-install`.

This is helpful for testing ament/ament_package#89.