### PR TITLE
Enable Windows build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
 endif()
 set(AMENT_PACKAGE_TEMPLATE_DIR "${AMENT_PACKAGE_DIR}/template")
 set(BINARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/path.${SHELL_EXT}")
-set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.${SHELL_EXT}")
 set(PYTHONPATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/pythonpath.${SHELL_EXT}.in")
 
 # register information for .dsv generation
@@ -43,6 +42,7 @@ set(
 if(WIN32)
   ament_environment_hooks("${BINARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
 else()
+  set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.${SHELL_EXT}")
   ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,13 @@ find_package(ament_cmake_core REQUIRED)
 execute_process(COMMAND python3 -c "from distutils import sysconfig; print(sysconfig.get_python_version())" OUTPUT_VARIABLE PYTHON_MAJOR_MINOR OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Locate ament_package template files.
-set(PYTHON_INSTALL_DIR "lib/python${PYTHON_MAJOR_MINOR}/site-packages")
+if(WIN32)
+  set(PYTHON_INSTALL_DIR "lib/site-packages")
+  set(SHELL_EXT "bat")
+else()
+  set(PYTHON_INSTALL_DIR "lib/python${PYTHON_MAJOR_MINOR}/site-packages")
+  set(SHELL_EXT "sh")
+endif()
 set(AMENT_PACKAGE_DIR "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package")
 if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
   # Check for an .egg-link file and use the listed directory if it exists
@@ -24,9 +30,9 @@ if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
   endif()
 endif()
 set(AMENT_PACKAGE_TEMPLATE_DIR "${AMENT_PACKAGE_DIR}/template")
-set(BINARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/path.sh")
-set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.sh")
-set(PYTHONPATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/pythonpath.sh.in")
+set(BINARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/path.${SHELL_EXT}")
+set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.${SHELL_EXT}")
+set(PYTHONPATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/pythonpath.${SHELL_EXT}.in")
 
 # register information for .dsv generation
 set(
@@ -34,7 +40,11 @@ set(
   "prepend-non-duplicate;PYTHONPATH;${PYTHON_INSTALL_DIR}")
 
 # Set environment hooks for default environment.
-ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
+if(WIN32)
+  ament_environment_hooks("${BINARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
+else()
+  ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
+endif()
 
 ament_package()
 ament_generate_environment()


### PR DESCRIPTION
This is motivated by an experiment of packaging ROS 2 into `conda` [packages](https://anaconda.org/ros-playground/repo), where this package is useful to generate the `local_setup.bat` related scripts, so I enable the `Windows` build for it.