### PR TITLE
set flag to skip parent_prefix_path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ else()
   ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" "env-hooks/multiarch_library_paths.sh.in")
 endif()
 
+# skip using ament_index/resource_index/parent_prefix_path
+# if for Debian packages it is known that there are no underlays
+# note the template only checks for an empty (use) / non-empty (skip) string
+set(SKIP_PARENT_PREFIX_PATH "SKIP_PARENT_PREFIX_PATH")
+
 ament_package()
 ament_generate_environment()
 


### PR DESCRIPTION
Fixes ros2/ros2#929. Uses ament/ament_package#115 (if that change isn't present this change will be a no-op therefore I didn't add a version dependency).

No CI since this isn't covered by it anyway but needs to be manually verified.