### PR TITLE
Use GNUInstallDirs to determine multiarch library dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,18 +43,23 @@ if(WIN32)
   ament_environment_hooks("${BINARY_PATH_HOOK}" "${PYTHONPATH_HOOK}")
 else()
   set(LIBRARY_PATH_HOOK "${AMENT_PACKAGE_TEMPLATE_DIR}/environment_hook/library_path.${SHELL_EXT}")
-  # Collect machine architecture triplet for libraries using GNU install dirs
-  execute_process(COMMAND gcc -dumpmachine OUTPUT_VARIABLE MULTIARCH_TRIPLET OUTPUT_STRIP_TRAILING_WHITESPACE)
-  # register multiarch information for .dsv generation
-  if(APPLE)
-    set(LIBRARY_PATH_ENV_VAR "DYLD_LIBRARY_PATH")
-  else()
-    set(LIBRARY_PATH_ENV_VAR "LD_LIBRARY_PATH")
+  # enable C language so that a trycompile can determine what the
+  # anticipated libdir will be.
+  enable_language(C)
+  include(GNUInstallDirs)
+  if(NOT ${CMAKE_INSTALL_LIBDIR} STREQUAL "lib")
+    # register multiarch information for .dsv generation
+    if(APPLE)
+      set(LIBRARY_PATH_ENV_VAR "DYLD_LIBRARY_PATH")
+    else()
+      set(LIBRARY_PATH_ENV_VAR "LD_LIBRARY_PATH")
+    endif()
+    set(
+      AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_multiarch_library_paths
+      "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};${CMAKE_INSTALL_LIBDIR}")
+    set(MULTIARCH_LIBRARY_PATH_HOOK "env-hooks/multiarch_library_paths.sh.in")
   endif()
-  set(
-    AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_multiarch_library_paths
-    "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};lib/${MULTIARCH_TRIPLET}")
-  ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" "env-hooks/multiarch_library_paths.sh.in")
+  ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK})
 endif()
 
 # skip using ament_index/resource_index/parent_prefix_path

--- a/env-hooks/multiarch_library_paths.sh.in
+++ b/env-hooks/multiarch_library_paths.sh.in
@@ -1,1 +1,1 @@
-ament_prepend_unique_value "@LIBRARY_PATH_ENV_VAR@" "$AMENT_CURRENT_PREFIX/lib/@MULTIARCH_TRIPLET@"
+ament_prepend_unique_value "@LIBRARY_PATH_ENV_VAR@" "$AMENT_CURRENT_PREFIX/@CMAKE_INSTALL_LIBDIR@"


### PR DESCRIPTION
The `CMAKE_INSTALL_LIBDIR` variable set by GNUInstallDirs contains the platform's preferred library directory name. On most platforms, this will be either `lib` or `lib64`. Debian does things a little differently - it always uses `lib`, but creates a subdirectory for each supported architecture.

In the end, the use case that drives this extra environment hook is a package that uses `CMAKE_INSTALL_LIBDIR` instead of using the ament pattern of just installing directly to `lib`. Rather than predict the debian-style pattern specifically, it supports more platforms and is less fragile to just let GNUInstallDirs do its thing and tell us where the libraries are expected to be placed.

One curiosity I noticed is that during local builds, GNUInstallDirs continued to report the `lib` directory for use on Ubuntu. After looking at the underlying script, it seems that because we're using a custom `CMAKE_INSTALL_PREFIX`, the script doesn't suffix the arch-specific directory like I was expecting. It turns out that debhelper actually [specifies a static `CMAKE_INSTALL_LIBDIR` value](https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/lib/Debian/Debhelper/Buildsystem/cmake.pm#L130) that overrides GNUInstallDirs. At first I thought we'd need extra logic to ensure the subdirectory is suffixed despite our non-standard `CMAKE_INSTALL_PREFIX`, but we actually just want to just let the dance play out normally, because that's what the downstream projects are going to do, too.

So in the end, we should see:
* Local builds on Debian should report `lib`, and this skip the hook
* Debian binary package builds should report `lib/arch-triple`, as [debhelper will override the GNUInstallDirs script](https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/lib/Debian/Debhelper/Buildsystem/cmake.pm#L130)
* Other platforms will report `lib64` or `lib` based on the system's `void *` size