### PR TITLE
Make ros_workspace have the prefix level templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,5 +68,28 @@ endif()
 set(SKIP_PARENT_PREFIX_PATH "SKIP_PARENT_PREFIX_PATH")
 
 ament_package()
-ament_generate_environment()
 
+# configure and install setup files
+foreach(file ${ament_cmake_package_templates_PREFIX_LEVEL})
+  # check if the file is a template
+  string_ends_with("${file}" ".in" is_template)
+  if(is_template)
+    # cut of .in extension
+    string(LENGTH "${file}" length)
+    math(EXPR offset "${length} - 3")
+    string(SUBSTRING "${file}" 0 ${offset} name)
+    # expand template
+    get_filename_component(name "${name}" NAME)
+    configure_file(
+      "${file}"
+      "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}"
+      @ONLY
+    )
+    set(file "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}")
+  endif()
+
+  install(
+    FILES "${file}"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  )
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,19 @@ set(SKIP_PARENT_PREFIX_PATH "SKIP_PARENT_PREFIX_PATH")
 
 ament_package()
 
+set(workspace_setup_files
+  "local_setup.bash"
+  "local_setup.bat.in"
+  "local_setup.sh.in"
+  "_local_setup_util.py"
+  "local_setup.zsh"
+  "setup.bash"
+  "setup.bat.in"
+  "setup.sh.in"
+  "setup.zsh")
+
 # configure and install setup files
-foreach(file ${ament_cmake_package_templates_PREFIX_LEVEL})
+foreach(file ${workspace_setup_files})
   # check if the file is a template
   string_ends_with("${file}" ".in" is_template)
   if(is_template)
@@ -82,10 +93,10 @@ foreach(file ${ament_cmake_package_templates_PREFIX_LEVEL})
     get_filename_component(name "${name}" NAME)
     configure_file(
       "${file}"
-      "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}"
+      "${CMAKE_BINARY_DIR}/ros_workspace_scripts/${name}"
       @ONLY
     )
-    set(file "${CMAKE_BINARY_DIR}/ament_cmake_environment/${name}")
+    set(file "${CMAKE_BINARY_DIR}/ros_workspace_scripts/${name}")
   endif()
 
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,6 @@ else()
   ament_environment_hooks("${BINARY_PATH_HOOK}" "${LIBRARY_PATH_HOOK}" "${PYTHONPATH_HOOK}" ${MULTIARCH_LIBRARY_PATH_HOOK})
 endif()
 
-# skip using ament_index/resource_index/parent_prefix_path
-# if for Debian packages it is known that there are no underlays
-# note the template only checks for an empty (use) / non-empty (skip) string
-set(SKIP_PARENT_PREFIX_PATH "SKIP_PARENT_PREFIX_PATH")
-
 ament_package()
 
 set(workspace_setup_files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ endif()
 
 ament_package()
 
+# make the path to the Python interpreter found at configure time available as a default
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+get_executable_path(ros_workspace_PYTHON_EXECUTABLE Python3::Interpreter CONFIGURE)
+
 set(workspace_setup_files
   "local_setup.bash"
   "local_setup.bat.in"

--- a/templates/_local_setup_util.py
+++ b/templates/_local_setup_util.py
@@ -1,0 +1,396 @@
+# Copyright 2016-2019 Dirk Thomas
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+from collections import OrderedDict
+import os
+from pathlib import Path
+import sys
+
+
+FORMAT_STR_COMMENT_LINE = None
+FORMAT_STR_SET_ENV_VAR = None
+FORMAT_STR_USE_ENV_VAR = None
+FORMAT_STR_INVOKE_SCRIPT = None
+FORMAT_STR_REMOVE_TRAILING_SEPARATOR = None
+
+DSV_TYPE_PREPEND_NON_DUPLICATE = 'prepend-non-duplicate'
+DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS = 'prepend-non-duplicate-if-exists'
+DSV_TYPE_SET = 'set'
+DSV_TYPE_SET_IF_UNSET = 'set-if-unset'
+DSV_TYPE_SOURCE = 'source'
+
+
+def main(argv=sys.argv[1:]):  # noqa: D103
+    global FORMAT_STR_COMMENT_LINE
+    global FORMAT_STR_SET_ENV_VAR
+    global FORMAT_STR_USE_ENV_VAR
+    global FORMAT_STR_INVOKE_SCRIPT
+    global FORMAT_STR_REMOVE_TRAILING_SEPARATOR
+
+    parser = argparse.ArgumentParser(
+        description='Output shell commands for the packages in topological '
+                    'order')
+    parser.add_argument(
+        'primary_extension',
+        help='The file extension of the primary shell')
+    parser.add_argument(
+        'additional_extension', nargs='?',
+        help='The additional file extension to be considered')
+    args = parser.parse_args(argv)
+
+    if args.primary_extension == 'sh':
+        FORMAT_STR_COMMENT_LINE = '# {comment}'
+        FORMAT_STR_SET_ENV_VAR = 'export {name}="{value}"'
+        FORMAT_STR_USE_ENV_VAR = '${name}'
+        FORMAT_STR_INVOKE_SCRIPT = 'AMENT_CURRENT_PREFIX="{prefix}" ' \
+            '_ament_prefix_sh_source_script "{script_path}"'
+        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if [ "$(echo -n ${name} | ' \
+            'tail -c 1)" = ":" ]; then export {name}=${{{name}%?}} ; fi'
+    elif args.primary_extension == 'bat':
+        FORMAT_STR_COMMENT_LINE = ':: {comment}'
+        FORMAT_STR_SET_ENV_VAR = 'set "{name}={value}"'
+        FORMAT_STR_USE_ENV_VAR = '%{name}%'
+        FORMAT_STR_INVOKE_SCRIPT = \
+            'call:_ament_prefix_bat_call_script "{script_path}"'
+        # can't use `if` here since each line is being `call`-ed
+        FORMAT_STR_REMOVE_TRAILING_SEPARATOR = \
+            'call:_ament_prefix_bat_strip_trailing_semicolon "{name}"'
+    else:
+        assert False, 'Unknown primary extension: ' + args.primary_extension
+
+    packages = get_packages(Path(__file__).parent)
+
+    ordered_packages = order_packages(packages)
+    for pkg_name in ordered_packages:
+        if _include_comments():
+            print(
+                FORMAT_STR_COMMENT_LINE.format_map(
+                    {'comment': 'Package: ' + pkg_name}))
+        prefix = os.path.abspath(os.path.dirname(__file__))
+        for line in get_commands(
+            pkg_name, prefix, args.primary_extension,
+            args.additional_extension
+        ):
+            print(line)
+
+    for line in _remove_trailing_separators():
+        print(line)
+
+
+def get_packages(prefix_path):
+    """
+    Find packages based on ament resource files created during installation.
+
+    :param Path prefix_path: The install prefix path of all packages
+    :returns: A mapping from the package name to the set of runtime
+      dependencies
+    :rtype: dict
+    """
+    packages = {}
+    # since importing ament_index_python isn't feasible here the following
+    # constant must match ament_index_python.constants.RESOURCE_INDEX_SUBFOLDER
+    subdirectory = 'share/ament_index/resource_index/packages'
+    # return if workspace is empty
+    if not (prefix_path / subdirectory).is_dir():
+        return packages
+    # find all files in the subdirectory
+    for p in (prefix_path / subdirectory).iterdir():
+        if not p.is_file():
+            continue
+        if p.name.startswith('.'):
+            continue
+        add_package_runtime_dependencies(p, packages)
+
+    # remove unknown dependencies
+    pkg_names = set(packages.keys())
+    for k in packages.keys():
+        packages[k] = {d for d in packages[k] if d in pkg_names}
+
+    return packages
+
+
+def add_package_runtime_dependencies(path, packages):
+    """
+    Check the path and if it exists extract the packages runtime dependencies.
+
+    :param Path path: The resource file containing the runtime dependencies
+    :param dict packages: A mapping from package names to the sets of runtime
+      dependencies to add to
+    """
+    dependencies = set()
+    marker_file = path.parents[1] / 'package_run_dependencies' / path.name
+    if marker_file.exists():
+        content = marker_file.read_text()
+        dependencies = set(content.split(';') if content else [])
+    packages[marker_file.name] = dependencies
+
+
+def order_packages(packages):
+    """
+    Order packages topologically.
+
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies
+    :returns: The package names
+    :rtype: list
+    """
+    # select packages with no dependencies in alphabetical order
+    to_be_ordered = list(packages.keys())
+    ordered = []
+    while to_be_ordered:
+        pkg_names_without_deps = [
+            name for name in to_be_ordered if not packages[name]]
+        if not pkg_names_without_deps:
+            reduce_cycle_set(packages)
+            raise RuntimeError(
+                'Circular dependency between: ' + ', '.join(sorted(packages)))
+        pkg_names_without_deps.sort()
+        pkg_name = pkg_names_without_deps[0]
+        to_be_ordered.remove(pkg_name)
+        ordered.append(pkg_name)
+        # remove item from dependency lists
+        for k in list(packages.keys()):
+            if pkg_name in packages[k]:
+                packages[k].remove(pkg_name)
+    return ordered
+
+
+def reduce_cycle_set(packages):
+    """
+    Reduce the set of packages to the ones part of the circular dependency.
+
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies which is modified in place
+    """
+    last_depended = None
+    while len(packages) > 0:
+        # get all remaining dependencies
+        depended = set()
+        for pkg_name, dependencies in packages.items():
+            depended = depended.union(dependencies)
+        # remove all packages which are not dependent on
+        for name in list(packages.keys()):
+            if name not in depended:
+                del packages[name]
+        if last_depended:
+            # if remaining packages haven't changed return them
+            if last_depended == depended:
+                return packages.keys()
+        # otherwise reduce again
+        last_depended = depended
+
+
+def _include_comments():
+    # skipping comment lines when AMENT_TRACE_SETUP_FILES is not set speeds up
+    # the processing especially on Windows
+    return bool(os.environ.get('AMENT_TRACE_SETUP_FILES'))
+
+
+def get_commands(pkg_name, prefix, primary_extension, additional_extension):
+    commands = []
+    package_dsv_path = os.path.join(prefix, 'share', pkg_name, 'package.dsv')
+    if os.path.exists(package_dsv_path):
+        commands += process_dsv_file(
+            package_dsv_path, prefix, primary_extension, additional_extension)
+    else:
+        for ext in (
+            [additional_extension] if additional_extension else []
+        ) + [primary_extension]:
+            package_ext_path = os.path.join(
+                prefix, 'share', pkg_name, 'local_setup.' + ext)
+            if os.path.exists(package_ext_path):
+                commands += [
+                    FORMAT_STR_INVOKE_SCRIPT.format_map({
+                        'prefix': prefix,
+                        'script_path': package_ext_path})]
+                break
+
+    return commands
+
+
+def process_dsv_file(
+    dsv_path, prefix, primary_extension=None, additional_extension=None
+):
+    commands = []
+    if _include_comments():
+        commands.append(
+            FORMAT_STR_COMMENT_LINE.format_map({'comment': dsv_path}))
+    with open(dsv_path, 'r') as h:
+        content = h.read()
+    lines = content.splitlines()
+
+    basenames = OrderedDict()
+    for i, line in enumerate(lines):
+        # skip over empty or whitespace-only lines
+        if not line.strip():
+            continue
+        try:
+            type_, remainder = line.split(';', 1)
+        except ValueError:
+            raise RuntimeError(
+                "Line %d in '%s' doesn't contain a semicolon separating the "
+                'type from the arguments' % (i + 1, dsv_path))
+        if type_ != DSV_TYPE_SOURCE:
+            # handle non-source lines
+            try:
+                commands += handle_dsv_types_except_source(
+                    type_, remainder, prefix)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "Line %d in '%s' %s" % (i + 1, dsv_path, e)) from e
+        else:
+            # group remaining source lines by basename
+            path_without_ext, ext = os.path.splitext(remainder)
+            assert ext.startswith('.')
+            ext = ext[1:]
+            if ext in (primary_extension, additional_extension):
+                if path_without_ext not in basenames:
+                    basenames[path_without_ext] = set()
+                basenames[path_without_ext].add(ext)
+
+    # add the dsv extension to each basename if the file exists
+    for basename, extensions in basenames.items():
+        if not os.path.isabs(basename):
+            basename = os.path.join(prefix, basename)
+        if os.path.exists(basename + '.dsv'):
+            extensions.add('dsv')
+
+    for basename, extensions in basenames.items():
+        if not os.path.isabs(basename):
+            basename = os.path.join(prefix, basename)
+        if 'dsv' in extensions:
+            # process dsv files recursively
+            commands += process_dsv_file(
+                basename + '.dsv', prefix, primary_extension=primary_extension,
+                additional_extension=additional_extension)
+        elif primary_extension in extensions and len(extensions) == 1:
+            # source primary-only files
+            commands += [
+                FORMAT_STR_INVOKE_SCRIPT.format_map({
+                    'prefix': prefix,
+                    'script_path': basename + '.' + primary_extension})]
+        elif additional_extension in extensions:
+            # source non-primary files
+            commands += [
+                FORMAT_STR_INVOKE_SCRIPT.format_map({
+                    'prefix': prefix,
+                    'script_path': basename + '.' + additional_extension})]
+
+    return commands
+
+
+def handle_dsv_types_except_source(type_, remainder, prefix):
+    commands = []
+    if type_ in (DSV_TYPE_SET, DSV_TYPE_SET_IF_UNSET):
+        try:
+            env_name, value = remainder.split(';', 1)
+        except ValueError:
+            raise RuntimeError(
+                "doesn't contain a semicolon separating the environment name "
+                'from the value')
+        try_prefixed_value = os.path.join(prefix, value) if value else prefix
+        if os.path.exists(try_prefixed_value):
+            value = try_prefixed_value
+        if type_ == DSV_TYPE_SET:
+            commands += _set(env_name, value)
+        elif type_ == DSV_TYPE_SET_IF_UNSET:
+            commands += _set_if_unset(env_name, value)
+        else:
+            assert False
+    elif type_ in (
+        DSV_TYPE_PREPEND_NON_DUPLICATE,
+        DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS
+    ):
+        try:
+            env_name_and_values = remainder.split(';')
+        except ValueError:
+            raise RuntimeError(
+                "doesn't contain a semicolon separating the environment name "
+                'from the values')
+        env_name = env_name_and_values[0]
+        values = env_name_and_values[1:]
+        for value in values:
+            if not value:
+                value = prefix
+            elif not os.path.isabs(value):
+                value = os.path.join(prefix, value)
+            if (
+                type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and
+                not os.path.exists(value)
+            ):
+                if _include_comments():
+                    comment = f'skip extending {env_name} with not existing ' \
+                        f'path: {value}'
+                    commands.append(
+                        FORMAT_STR_COMMENT_LINE.format_map({'comment': comment}))
+            else:
+                commands += _prepend_unique_value(env_name, value)
+    else:
+        raise RuntimeError(
+            'contains an unknown environment hook type: ' + type_)
+    return commands
+
+
+env_state = {}
+
+
+def _prepend_unique_value(name, value):
+    global env_state
+    if name not in env_state:
+        if os.environ.get(name):
+            env_state[name] = set(os.environ[name].split(os.pathsep))
+        else:
+            env_state[name] = set()
+    # prepend even if the variable has not been set yet, in case a shell script sets the
+    # same variable without the knowledge of this Python script.
+    # later _remove_trailing_separators() will cleanup any unintentional trailing separator
+    extend = os.pathsep + FORMAT_STR_USE_ENV_VAR.format_map({'name': name})
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value + extend})
+    if value not in env_state[name]:
+        env_state[name].add(value)
+    else:
+        if not _include_comments():
+            return []
+        line = FORMAT_STR_COMMENT_LINE.format_map({'comment': line})
+    return [line]
+
+
+def _remove_trailing_separators():
+    global env_state
+    commands = []
+    for name in env_state:
+        # skip variables that already had values before this script started prepending
+        if name in os.environ:
+            continue
+        commands += [FORMAT_STR_REMOVE_TRAILING_SEPARATOR.format_map(
+            {'name': name})]
+    return commands
+
+
+def _set(name, value):
+    global env_state
+    env_state[name] = value
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value})
+    return [line]
+
+
+def _set_if_unset(name, value):
+    global env_state
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value})
+    if env_state.get(name, os.environ.get(name)):
+        line = FORMAT_STR_COMMENT_LINE.format_map({'comment': line})
+    return [line]
+
+
+if __name__ == '__main__':  # pragma: no cover
+    try:
+        rc = main()
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        rc = 1
+    sys.exit(rc)

--- a/templates/local_setup.bash
+++ b/templates/local_setup.bash
@@ -1,0 +1,11 @@
+# copied from ament_package/template/prefix_level/local_setup.bash
+
+AMENT_SHELL=bash
+
+# source local_setup.sh from same directory as this file
+AMENT_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" && pwd)
+# trace output
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$AMENT_CURRENT_PREFIX/local_setup.sh\""
+fi
+. "$AMENT_CURRENT_PREFIX/local_setup.sh"

--- a/templates/local_setup.bash
+++ b/templates/local_setup.bash
@@ -1,4 +1,4 @@
-# copied from ament_package/template/prefix_level/local_setup.bash
+# copied from ros_workspace/templates/local_setup.bash
 
 AMENT_SHELL=bash
 

--- a/templates/local_setup.bat.in
+++ b/templates/local_setup.bat.in
@@ -1,0 +1,78 @@
+:: generated from ament_package/template/prefix_level/local_setup.bat.in
+@echo off
+
+:: get and run all commands in topological order
+call:_ament_run_ordered_commands "%~dp0"
+
+goto:eof
+
+
+:: Run the commands in topological order
+:: first argument: the base path to look for packages
+:_ament_run_ordered_commands
+  setlocal enabledelayedexpansion
+  :: check environment variable for custom Python executable
+  if "%AMENT_PYTHON_EXECUTABLE%" NEQ "" (
+    if not exist "%AMENT_PYTHON_EXECUTABLE%" (
+      echo error: AMENT_PYTHON_EXECUTABLE '%AMENT_PYTHON_EXECUTABLE%' doesn't exist
+      exit /b 1
+    )
+    set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
+  ) else (
+    :: use the Python executable known at configure time
+    set "_ament_python_executable=@PYTHON_EXECUTABLE@"
+    :: if it doesn't exist try a fall back
+    if not exist "!_ament_python_executable!" (
+      python --version > NUL 2> NUL
+      if errorlevel 1 (
+        echo error: unable to find python executable
+        exit /b 1
+      )
+      set "_ament_python_executable=python"
+    )
+  )
+
+  endlocal & (
+    set "_ament_python_executable=%_ament_python_executable%"
+  )
+
+  :: escape potential closing parenthesis which would break the for loop
+  set "ament_python_executable=%ament_python_executable:)=^)%"
+  for /f "delims=" %%c in ('""%_ament_python_executable%" "%~1_local_setup_util.py" bat"') do (
+    if "%AMENT_TRACE_SETUP_FILES%" NEQ "" (
+      echo %%c
+    )
+    :: only invoke non-comment lines
+    echo %%c | findstr /r "^::" >nul 2>&1
+    if errorlevel 1 (
+      call %%c
+    )
+  )
+  set _ament_python_executable=
+goto:eof
+
+
+:: call the specified batch file and output the name when tracing is requested
+:: first argument: the batch file
+:_ament_prefix_bat_call_script
+  if exist "%~1" (
+    if "%AMENT_TRACE_SETUP_FILES%" NEQ "" echo call "%~1"
+    call "%~1%"
+  ) else (
+    echo not found: "%~1" 1>&2
+  )
+goto:eof
+
+
+:: strip a trailing semicolon from an environment variable if applicable
+:: first argument: the environment variable name
+:_ament_prefix_bat_strip_trailing_semicolon
+  setlocal enabledelayedexpansion
+  set "name=%~1"
+  set "value=!%name%!"
+  if "%value:~-1%"==";" set "value=%value:~0,-1%"
+  :: set result variable in parent scope
+  endlocal & (
+    set "%~1=%value%"
+  )
+goto:eof

--- a/templates/local_setup.bat.in
+++ b/templates/local_setup.bat.in
@@ -20,7 +20,7 @@ goto:eof
     set "_ament_python_executable=%AMENT_PYTHON_EXECUTABLE%"
   ) else (
     :: use the Python executable known at configure time
-    set "_ament_python_executable=@PYTHON_EXECUTABLE@"
+    set "_ament_python_executable=@ros_workspace_PYTHON_EXECUTABLE@"
     :: if it doesn't exist try a fall back
     if not exist "!_ament_python_executable!" (
       python --version > NUL 2> NUL

--- a/templates/local_setup.bat.in
+++ b/templates/local_setup.bat.in
@@ -1,4 +1,4 @@
-:: generated from ament_package/template/prefix_level/local_setup.bat.in
+:: generated from ros_workspace/templates/local_setup.bat.in
 @echo off
 
 :: get and run all commands in topological order

--- a/templates/local_setup.sh.in
+++ b/templates/local_setup.sh.in
@@ -1,0 +1,131 @@
+# generated from ament_package/template/prefix_level/local_setup.sh.in
+
+# since a plain shell script can't determine its own path when being sourced
+# either use the provided AMENT_CURRENT_PREFIX
+# or fall back to the build time prefix (if it exists)
+_ament_prefix_sh_AMENT_CURRENT_PREFIX="@CMAKE_INSTALL_PREFIX@"
+if [ -z "$AMENT_CURRENT_PREFIX" ]; then
+  if [ ! -d "$_ament_prefix_sh_AMENT_CURRENT_PREFIX" ]; then
+    echo "The build time path \"$_ament_prefix_sh_AMENT_CURRENT_PREFIX\" doesn't exist. Either source a script for a different shell or set the environment variable \"AMENT_CURRENT_PREFIX\" explicitly." 1>&2
+    unset _ament_prefix_sh_AMENT_CURRENT_PREFIX
+    return 1
+  fi
+else
+  _ament_prefix_sh_AMENT_CURRENT_PREFIX="$AMENT_CURRENT_PREFIX"
+fi
+
+# set type of shell if not already set
+: ${AMENT_SHELL:=sh}
+
+# use the Python executable known at configure time
+_ament_python_executable="@PYTHON_EXECUTABLE@"
+# allow overriding it with a custom location
+if [ -n "$AMENT_PYTHON_EXECUTABLE" ]; then
+  _ament_python_executable="$AMENT_PYTHON_EXECUTABLE"
+fi
+# if the Python executable doesn't exist try another fall back
+if [ ! -f "$_ament_python_executable" ]; then
+  if /usr/bin/env python3 --version > /dev/null
+  then
+    _ament_python_executable=`/usr/bin/env python3 -c "import sys; print(sys.executable)"`
+  else
+    echo error: unable to find fallback python3 executable
+    return 1
+  fi
+fi
+
+# function to source another script with conditional trace output
+# first argument: the path of the script
+_ament_prefix_sh_source_script() {
+  if [ -f "$1" ]; then
+    if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+      echo "# . \"$1\""
+    fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}
+
+# function to prepend non-duplicate values to environment variables
+# using colons as separators and avoiding trailing separators
+ament_prepend_unique_value() {
+  # arguments
+  _listname="$1"
+  _value="$2"
+  #echo "listname $_listname"
+  #eval echo "list value \$$_listname"
+  #echo "value $_value"
+
+  # check if the list contains the value
+  eval _values=\"\$$_listname\"
+  _duplicate=
+  _ament_prepend_unique_value_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _values
+  fi
+  for _item in $_values; do
+    # ignore empty strings
+    if [ -z "$_item" ]; then
+      continue
+    fi
+    if [ "$_item" = "$_value" ]; then
+      _duplicate=1
+    fi
+  done
+  unset _item
+
+  # prepend only non-duplicates
+  if [ -z "$_duplicate" ]; then
+    # avoid trailing separator
+    if [ -z "$_values" ]; then
+      eval export $_listname=\"$_value\"
+      #eval echo "set list \$$_listname"
+    else
+      # field separator must not be a colon
+      unset IFS
+      eval export $_listname=\"$_value:\$$_listname\"
+      #eval echo "prepend list \$$_listname"
+    fi
+  fi
+  IFS=$_ament_prepend_unique_value_IFS
+  unset _ament_prepend_unique_value_IFS
+  unset _duplicate
+  unset _values
+
+  unset _value
+  unset _listname
+}
+
+# get all commands in topological order
+_ament_additional_extension=""
+if [ "$AMENT_SHELL" != "sh" ]; then
+  _ament_additional_extension="${AMENT_SHELL}"
+fi
+_ament_ordered_commands="$($_ament_python_executable "$_ament_prefix_sh_AMENT_CURRENT_PREFIX/_local_setup_util.py" sh $_ament_additional_extension)"
+unset _ament_additional_extension
+unset _ament_python_executable
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "_ament_prefix_sh_source_script() {
+    if [ -f \"\$1\" ]; then
+      if [ -n \"\$AMENT_TRACE_SETUP_FILES\" ]; then
+        echo \"# . \\\"\$1\\\"\"
+      fi
+      . \"\$1\"
+    else
+      echo \"not found: \\\"\$1\\\"\" 1>&2
+    fi
+  }"
+  echo "# Execute generated script:"
+  echo "# <<<"
+  echo "${_ament_ordered_commands}"
+  echo "# >>>"
+  echo "unset _ament_prefix_sh_source_script"
+fi
+eval "${_ament_ordered_commands}"
+unset _ament_ordered_commands
+
+unset _ament_prefix_sh_source_script
+
+unset _ament_prefix_sh_AMENT_CURRENT_PREFIX

--- a/templates/local_setup.sh.in
+++ b/templates/local_setup.sh.in
@@ -18,7 +18,7 @@ fi
 : ${AMENT_SHELL:=sh}
 
 # use the Python executable known at configure time
-_ament_python_executable="@PYTHON_EXECUTABLE@"
+_ament_python_executable="@ros_workspace_PYTHON_EXECUTABLE@"
 # allow overriding it with a custom location
 if [ -n "$AMENT_PYTHON_EXECUTABLE" ]; then
   _ament_python_executable="$AMENT_PYTHON_EXECUTABLE"

--- a/templates/local_setup.sh.in
+++ b/templates/local_setup.sh.in
@@ -1,4 +1,4 @@
-# generated from ament_package/template/prefix_level/local_setup.sh.in
+# generated from ros_workspace/templates/local_setup.sh.in
 
 # since a plain shell script can't determine its own path when being sourced
 # either use the provided AMENT_CURRENT_PREFIX

--- a/templates/local_setup.zsh
+++ b/templates/local_setup.zsh
@@ -1,0 +1,11 @@
+# copied from ament_package/template/prefix_level/local_setup.zsh
+
+AMENT_SHELL=zsh
+
+# source local_setup.sh from same directory as this file
+AMENT_CURRENT_PREFIX=$(builtin cd -q "`dirname "${(%):-%N}"`" > /dev/null && pwd)
+# trace output
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$AMENT_CURRENT_PREFIX/local_setup.sh\""
+fi
+. "$AMENT_CURRENT_PREFIX/local_setup.sh"

--- a/templates/local_setup.zsh
+++ b/templates/local_setup.zsh
@@ -1,4 +1,4 @@
-# copied from ament_package/template/prefix_level/local_setup.zsh
+# copied from ros_workspace/templates/local_setup.zsh
 
 AMENT_SHELL=zsh
 

--- a/templates/setup.bash
+++ b/templates/setup.bash
@@ -1,0 +1,11 @@
+# copied from ament_package/template/prefix_level/setup.bash
+
+AMENT_SHELL=bash
+
+# source setup.sh from same directory as this file
+AMENT_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" && pwd)
+# trace output
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$AMENT_CURRENT_PREFIX/setup.sh\""
+fi
+. "$AMENT_CURRENT_PREFIX/setup.sh"

--- a/templates/setup.bash
+++ b/templates/setup.bash
@@ -1,4 +1,4 @@
-# copied from ament_package/template/prefix_level/setup.bash
+# copied from ros_workspace/templates/setup.bash
 
 AMENT_SHELL=bash
 

--- a/templates/setup.bat.in
+++ b/templates/setup.bat.in
@@ -1,0 +1,115 @@
+:: generated from ament_package/template/prefix_level/setup.bat.in
+@echo off
+
+:: get the directory of this file without trailing backslash
+set "_current_prefix_path=%~dp0"
+if %_current_prefix_path:~-1%==\ set _current_prefix_path=%_current_prefix_path:~0,-1%
+
+:: find parent prefix path files for all packages under the current prefix
+call:list_files _resource_names "%_current_prefix_path%\share\ament_index\resource_index\parent_prefix_path"
+
+:: get the unique parent prefix path in reverse order
+call:get_prefix_path _unique_reverse_prefix_path "%_current_prefix_path%" "%_resource_names%"
+set "_resource_names="
+
+:: append this directory to the prefix path
+call:ament_append_unique_value _unique_reverse_prefix_path "%_current_prefix_path%"
+set "_current_prefix_path="
+
+:: source local_setup.bat file for each prefix path
+for %%p in ("%_unique_reverse_prefix_path:;=";"%") do (
+  call:call_file "%%~p\local_setup.bat"
+)
+set "_unique_reverse_prefix_path="
+
+:: end of script
+goto:eof
+
+
+:: List the files in a directory in alphabetical order.
+:: first argument: the name of the result variable
+:: second argument: the directory
+:list_files
+  setlocal enabledelayedexpansion
+  set "files="
+  for /f %%f in ('dir /b "%~2"') do (
+    if "!files!" NEQ "" set "files=!files!;"
+    set "files=!files!%%~f"
+  )
+  endlocal & (
+    :: set result variable in parent scope
+    set "%~1=%files%"
+  )
+goto:eof
+
+:: Iterate over all parent_prefix_path files and
+:: get the unique parent prefix path in reverse order.
+:: first argument: the name of the result variable
+:: second parameter: the prefix path names
+:: third parameter: the resource names
+:get_prefix_path
+  setlocal enabledelayedexpansion
+  set "prefix_path="
+  set "resource_names=%~3"
+  if "%resource_names%" NEQ "" (
+    for %%a in ("%resource_names:;=";"%") do (
+      :: reset variable otherwise it keeps its previous value if the file is empty
+      set "reverse_ppp="
+      for /f "tokens=1 delims=" %%p in (%~2\share\ament_index\resource_index\parent_prefix_path\%%~a) do (
+        if "!reverse_ppp!" NEQ "" set "reverse_ppp=;!reverse_ppp!"
+        :: replace placeholder of current prefix
+        if "%%~p" EQU "{prefix}" (
+          set "p=%~2"
+        )
+        set "reverse_ppp=%%~p!reverse_ppp!"
+      )
+
+      :: append unique prefix path
+      for %%p in ("!reverse_ppp:;=";"!") do (
+        call:ament_append_unique_value prefix_path "%%~p"
+      )
+    )
+  )
+  endlocal & (
+    :: set result variable in parent scope
+    set "%~1=%prefix_path%"
+  )
+goto:eof
+
+:: Append non-duplicate values to environment variables
+:: using semicolons as separators and avoiding trailing separators.
+:: first argument: the name of the result variable
+:: second argument: the value
+:ament_append_unique_value
+  setlocal enabledelayedexpansion
+  :: arguments
+  set "listname=%~1"
+  set "value=%~2"
+  :: expand the list variable
+  set "list=!%listname%!"
+  :: check if the list contains the value
+  set "is_duplicate="
+  if "%list%" NEQ "" (
+    for %%v in ("%list:;=";"%") do (
+      if "%%~v" == "%value%" set "is_duplicate=1"
+    )
+  )
+  :: if it is not a duplicate append it
+  if "%is_duplicate%" == "" (
+    :: if not empty, append a semi-colon
+    if "!list!" NEQ "" set "list=!list!;"
+    :: append the value
+    set "list=!list!%value%"
+  )
+  endlocal & (
+    :: set result variable in parent scope
+    set "%~1=%list%"
+  )
+goto:eof
+
+:: Call the specified batch file and output the name when tracing is requested.
+:: first argument: the batch file
+:call_file
+  if "%AMENT_TRACE_SETUP_FILES%" NEQ "" echo call "%~1"
+  if exist "%~1" call "%~1%"
+goto:eof

--- a/templates/setup.bat.in
+++ b/templates/setup.bat.in
@@ -1,4 +1,4 @@
-:: generated from ament_package/template/prefix_level/setup.bat.in
+:: generated from ros_workspace/templates/setup.bat.in
 @echo off
 
 :: get the directory of this file without trailing backslash

--- a/templates/setup.sh.in
+++ b/templates/setup.sh.in
@@ -1,0 +1,144 @@
+# generated from ament_package/template/prefix_level/setup.sh.in
+
+# since this file is sourced use either the provided AMENT_CURRENT_PREFIX
+# or fall back to the destination set at configure time
+: ${AMENT_CURRENT_PREFIX:=@CMAKE_INSTALL_PREFIX@}
+
+# set type of shell if not already set
+: ${AMENT_SHELL:=sh}
+
+# function to append non-duplicate values to environment variables
+# using colons as separators and avoiding leading separators
+ament_append_unique_value() {
+  # arguments
+  _listname=$1
+  _value=$2
+  #echo "listname $_listname"
+  #eval echo "list value \$$_listname"
+  #echo "value $_value"
+
+  # check if the list contains the value
+  eval _values=\$$_listname
+  _duplicate=
+  _ament_append_unique_value_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _values
+  fi
+  for _item in $_values; do
+    # ignore empty strings
+    if [ -z "$_item" ]; then
+      continue
+    fi
+    if [ $_item = $_value ]; then
+      _duplicate=1
+    fi
+  done
+  unset _item
+
+  # append only non-duplicates
+  if [ -z "$_duplicate" ]; then
+    # avoid leading separator
+    if [ -z "$_values" ]; then
+      eval $_listname=\"$_value\"
+      #eval echo "set list \$$_listname"
+    else
+      # field separator must not be a colon
+      unset IFS
+      eval $_listname=\"\$$_listname:$_value\"
+      #eval echo "append list \$$_listname"
+    fi
+  fi
+  IFS=$_ament_append_unique_value_IFS
+  unset _ament_append_unique_value_IFS
+  unset _duplicate
+  unset _values
+
+  unset _value
+  unset _listname
+}
+
+# iterate over all parent_prefix_path files
+_prefix_setup_IFS=$IFS
+IFS="
+"
+# this variable contains the concatenated prefix paths in reverse order
+_UNIQUE_PREFIX_PATH=""
+
+# this check is used to skip parent prefix path in the Debian package
+if [ -z "@SKIP_PARENT_PREFIX_PATH@" ]; then
+  # find parent prefix path files for all packages under the current prefix
+  _RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_index/resource_index/parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
+
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _RESOURCES
+  fi
+  for _resource in $_RESOURCES; do
+    # read the content of the parent_prefix_path file
+    _PARENT_PREFIX_PATH="$(\cat "$_resource")"
+    # reverse the list
+    _REVERSED_PARENT_PREFIX_PATH=""
+    IFS=":"
+    if [ "$AMENT_SHELL" = "zsh" ]; then
+      ament_zsh_to_array _PARENT_PREFIX_PATH
+    fi
+    for _path in $_PARENT_PREFIX_PATH; do
+      # replace placeholder of current prefix
+      if [ "$_path" = "{prefix}" ]; then
+        _path="$AMENT_CURRENT_PREFIX"
+      fi
+      # avoid leading separator
+      if [ -z "$_REVERSED_PARENT_PREFIX_PATH" ]; then
+        _REVERSED_PARENT_PREFIX_PATH=$_path
+      else
+        _REVERSED_PARENT_PREFIX_PATH=$_path:$_REVERSED_PARENT_PREFIX_PATH
+      fi
+    done
+    unset _PARENT_PREFIX_PATH
+    # collect all unique parent prefix path
+    if [ "$AMENT_SHELL" = "zsh" ]; then
+      ament_zsh_to_array _REVERSED_PARENT_PREFIX_PATH
+    fi
+    for _path in $_REVERSED_PARENT_PREFIX_PATH; do
+      ament_append_unique_value _UNIQUE_PREFIX_PATH "$_path"
+    done
+    unset _REVERSED_PARENT_PREFIX_PATH
+  done
+  unset _resource
+  unset _RESOURCES
+fi
+
+# append this directory to the prefix path
+ament_append_unique_value _UNIQUE_PREFIX_PATH "$AMENT_CURRENT_PREFIX"
+unset AMENT_CURRENT_PREFIX
+
+# store AMENT_SHELL to restore it after each prefix
+_prefix_setup_AMENT_SHELL=$AMENT_SHELL
+# source local_setup.EXT or local_setup.sh file for each prefix path
+IFS=":"
+if [ "$AMENT_SHELL" = "zsh" ]; then
+  ament_zsh_to_array _UNIQUE_PREFIX_PATH
+fi
+for _path in $_UNIQUE_PREFIX_PATH; do
+  # trace output
+  if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+    echo "# . \"$_path/local_setup.$AMENT_SHELL\""
+  fi
+  if [ -f "$_path/local_setup.$AMENT_SHELL" ]; then
+    if [ "$AMENT_SHELL" = "sh" ]; then
+      # provide AMENT_CURRENT_PREFIX to .sh files
+      AMENT_CURRENT_PREFIX=$_path
+    fi
+    # restore IFS before sourcing other files
+    IFS=$_prefix_setup_IFS
+    . "$_path/local_setup.$AMENT_SHELL"
+    # restore AMENT_SHELL after each prefix-level local_setup file
+    AMENT_SHELL=$_prefix_setup_AMENT_SHELL
+  fi
+done
+unset _path
+IFS=$_prefix_setup_IFS
+unset _prefix_setup_IFS
+unset _prefix_setup_AMENT_SHELL
+unset _UNIQUE_PREFIX_PATH
+unset AMENT_SHELL

--- a/templates/setup.sh.in
+++ b/templates/setup.sh.in
@@ -1,4 +1,4 @@
-# generated from ament_package/template/prefix_level/setup.sh.in
+# generated from ros_workspace/templates/setup.sh.in
 
 # since this file is sourced use either the provided AMENT_CURRENT_PREFIX
 # or fall back to the destination set at configure time

--- a/templates/setup.sh.in
+++ b/templates/setup.sh.in
@@ -65,49 +65,6 @@ IFS="
 # this variable contains the concatenated prefix paths in reverse order
 _UNIQUE_PREFIX_PATH=""
 
-# this check is used to skip parent prefix path in the Debian package
-if [ -z "@SKIP_PARENT_PREFIX_PATH@" ]; then
-  # find parent prefix path files for all packages under the current prefix
-  _RESOURCES="$(\find "$AMENT_CURRENT_PREFIX/share/ament_index/resource_index/parent_prefix_path" -mindepth 1 -maxdepth 1 2> /dev/null | \sort)"
-
-  if [ "$AMENT_SHELL" = "zsh" ]; then
-    ament_zsh_to_array _RESOURCES
-  fi
-  for _resource in $_RESOURCES; do
-    # read the content of the parent_prefix_path file
-    _PARENT_PREFIX_PATH="$(\cat "$_resource")"
-    # reverse the list
-    _REVERSED_PARENT_PREFIX_PATH=""
-    IFS=":"
-    if [ "$AMENT_SHELL" = "zsh" ]; then
-      ament_zsh_to_array _PARENT_PREFIX_PATH
-    fi
-    for _path in $_PARENT_PREFIX_PATH; do
-      # replace placeholder of current prefix
-      if [ "$_path" = "{prefix}" ]; then
-        _path="$AMENT_CURRENT_PREFIX"
-      fi
-      # avoid leading separator
-      if [ -z "$_REVERSED_PARENT_PREFIX_PATH" ]; then
-        _REVERSED_PARENT_PREFIX_PATH=$_path
-      else
-        _REVERSED_PARENT_PREFIX_PATH=$_path:$_REVERSED_PARENT_PREFIX_PATH
-      fi
-    done
-    unset _PARENT_PREFIX_PATH
-    # collect all unique parent prefix path
-    if [ "$AMENT_SHELL" = "zsh" ]; then
-      ament_zsh_to_array _REVERSED_PARENT_PREFIX_PATH
-    fi
-    for _path in $_REVERSED_PARENT_PREFIX_PATH; do
-      ament_append_unique_value _UNIQUE_PREFIX_PATH "$_path"
-    done
-    unset _REVERSED_PARENT_PREFIX_PATH
-  done
-  unset _resource
-  unset _RESOURCES
-fi
-
 # append this directory to the prefix path
 ament_append_unique_value _UNIQUE_PREFIX_PATH "$AMENT_CURRENT_PREFIX"
 unset AMENT_CURRENT_PREFIX

--- a/templates/setup.zsh
+++ b/templates/setup.zsh
@@ -1,0 +1,22 @@
+# copied from ament_package/template/prefix_level/setup.zsh
+
+AMENT_SHELL=zsh
+
+# source setup.sh from same directory as this file
+AMENT_CURRENT_PREFIX=$(builtin cd -q "`dirname "${(%):-%N}"`" > /dev/null && pwd)
+
+# function to convert array-like strings into arrays
+# to wordaround SH_WORD_SPLIT not being set
+ament_zsh_to_array() {
+  local _listname=$1
+  local _dollar="$"
+  local _split="{="
+  local _to_array="(\"$_dollar$_split$_listname}\")"
+  eval $_listname=$_to_array
+}
+
+# trace output
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$AMENT_CURRENT_PREFIX/setup.sh\""
+fi
+. "$AMENT_CURRENT_PREFIX/setup.sh"

--- a/templates/setup.zsh
+++ b/templates/setup.zsh
@@ -1,4 +1,4 @@
-# copied from ament_package/template/prefix_level/setup.zsh
+# copied from ros_workspace/templates/setup.zsh
 
 AMENT_SHELL=zsh
 


### PR DESCRIPTION
Opening for discussion. I haven't tested this locally. The commits are structured to show what was copied and what was changed.

This makes `ros_workspace` the owner of the `prefix_level` templates currently in `ament_package`.

Follow up from https://github.com/ament/ament_cmake/pull/354#discussion_r684532813