### PR TITLE
CMakeLists: Fix Cross Compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
   set(PYTHON_INSTALL_DIR "lib/python${PYTHON_MAJOR_MINOR}/site-packages")
   set(SHELL_EXT "sh")
 endif()
-set(AMENT_PACKAGE_DIR "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/ament_package")
+set(AMENT_PACKAGE_DIR "${CMAKE_PREFIX_PATH}/${PYTHON_INSTALL_DIR}/ament_package")
 if(NOT EXISTS "${AMENT_PACKAGE_DIR}")
   # Check for an .egg-link file and use the listed directory if it exists
   get_filename_component(AMENT_PACKAGE_EGG_LINK "${AMENT_PACKAGE_DIR}" DIRECTORY)


### PR DESCRIPTION
When Cross compiling, the CMAKE_INSTALL_PREFIX (i.e. target) might be different from the CMAKE_PREFIX_PATH (i.e. host). In order, to properly cross-compile, use the CMAKE_PREFIX_PATH instead of CMAKE_INSTALL_PREFIX.

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>